### PR TITLE
UCM: Avoid using thread-local-storage as recursion guard.

### DIFF
--- a/contrib/test_jenkins.sh
+++ b/contrib/test_jenkins.sh
@@ -103,8 +103,13 @@ if [ -n "$JENKINS_RUN_TESTS" ]; then
 
     done
 
-    echo "Running MPI tests"
+    echo "Running memory hook on MPI"
     mpirun -np 1 -mca pml ob1 -mca btl sm,self -mca coll ^hcoll,ml $AFFINITY ./test/mpi/test_memhooks
+
+    echo "Running memory hook on MPI with LD_PRELOAD"
+    ucm_lib=$PWD/src/ucm/.libs/libucm.so
+    ls -l $ucm_lib
+    mpirun -np 1 -mca pml ob1 -mca btl sm,self -mca coll ^hcoll,ml -x LD_PRELOAD=$ucm_lib $AFFINITY ./test/mpi/test_memhooks
 
     module unload hpcx-gcc
 

--- a/src/ucm/mmap/install.c
+++ b/src/ucm/mmap/install.c
@@ -13,7 +13,7 @@
 #include <ucm/api/ucm.h>
 #include <ucm/event/event.h>
 #include <ucm/util/log.h>
-#include "../util/reloc.h"
+#include <ucm/util/reloc.h>
 #include <ucm/util/ucm_config.h>
 
 #include <sys/mman.h>


### PR DESCRIPTION
 Thread local storage may trigger memory allocations, so it's unsuitable
to be used to detect recursion when calling original memory mapping
function. Instead, save the current thread which tries to resolve an
original symbol in a global variable protected by a mutex, and fail if
the same thread tries to call a mapping function.
 Also, add a mpi memory hooks test with LD_PRELOAD to jenkins.